### PR TITLE
Remove duplicate code in `printing/tests/test_latex.py`

### DIFF
--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2622,9 +2622,6 @@ def test_latex_decimal_separator():
 
     assert(latex(Mul(3.4,5.3), decimal_separator = 'comma') == r'18{,}02')
     assert(latex(3.4*5.3, decimal_separator = 'comma') == r'18{,}02')
-    x = symbols('x')
-    y = symbols('y')
-    z = symbols('z')
     assert(latex(x*5.3 + 2**y**3.4 + 4.5 + z, decimal_separator = 'comma') == r'2^{y^{3{,}4}} + 5{,}3 x + z + 4{,}5')
 
     assert(latex(0.987, decimal_separator='comma') == r'0{,}987')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Removed re-declaration of symbols `x, y, z`

#### Other comments
x, y, z are already declared in line [2601](https://github.com/sympy/sympy/blob/f9badb21b01f4f52ce4d545d071086ee650cd282/sympy/printing/tests/test_latex.py#L2601)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
